### PR TITLE
redis script load before executing scripts

### DIFF
--- a/lib/redis/scripting/module.rb
+++ b/lib/redis/scripting/module.rb
@@ -12,7 +12,7 @@ class Module
     @redis = redis
     @source_dir = source_dir
     @scripts = {}
-    load_scripts()
+    load_scripts(opts[:preheat_scripts_cache])
   end
 
   def run(script_name, keys, argv, redis = self.redis)
@@ -28,7 +28,7 @@ class Module
 
   private
 
-  def load_scripts
+  def load_scripts(preheat_scripts_cache = false)
     headers = Dir.glob(File.join(source_dir, "includes", "*.lua")).map { |include_name|
       File.read(include_name)
     }
@@ -39,7 +39,9 @@ class Module
 
     Dir.glob(File.join(source_dir, "*.lua")).each do |filename|
       script = Redis::Scripting::Script.new(filename, script_header: header_source)
-      script.load(redis)
+      if preheat_scripts_cache
+        script.load(redis)
+      end
       @scripts[script.name] = script
     end
   end

--- a/lib/redis/scripting/module.rb
+++ b/lib/redis/scripting/module.rb
@@ -39,6 +39,7 @@ class Module
 
     Dir.glob(File.join(source_dir, "*.lua")).each do |filename|
       script = Redis::Scripting::Script.new(filename, script_header: header_source)
+      script.load(redis)
       @scripts[script.name] = script
     end
   end

--- a/lib/redis/scripting/script.rb
+++ b/lib/redis/scripting/script.rb
@@ -27,6 +27,10 @@ class Script
   def sha
     @sha ||= OpenSSL::Digest::SHA1.hexdigest(source)
   end
+
+  def load(redis)
+    redis.script(:load, source)
+  end
 end
 
 end


### PR DESCRIPTION
Avoids Redis::CommandError: NOSCRIPT when executing scripts in redis.pipelined 
